### PR TITLE
Convert PointXYZ to PointXYZRGB to add colour support

### DIFF
--- a/pcl/_pcl.pyx
+++ b/pcl/_pcl.pyx
@@ -2,6 +2,7 @@
 
 from collections import Sequence
 import numbers
+import struct
 import numpy as np
 
 cimport numpy as cnp
@@ -52,6 +53,23 @@ SACMODEL_STICK = cpp.SACMODEL_STICK
 
 cnp.import_array()
 
+# RGB helper functions
+def rgb_to_float(r, g, b):
+    rgb = r << 16 | g << 8 | b
+    # p.rgb = *reinterpret_cast<float*>(&rgb);
+    rgb_bytes = struct.pack('I', rgb)
+    p_rgb = struct.unpack('f', rgb_bytes)[0]
+    return p_rgb
+
+def float_to_rgb(p_rgb):
+    # rgb = *reinterpret_cast<int*>(&p.rgb)
+    rgb_bytes = struct.pack('f', p_rgb)
+    rgb = struct.unpack('I', rgb_bytes)[0]
+
+    r = (rgb >> 16) & 0x0000ff
+    g = (rgb >> 8)  & 0x0000ff
+    b = (rgb)       & 0x0000ff
+    return r,g,b
 
 cdef class Segmentation:
     """
@@ -172,7 +190,7 @@ cdef class PointCloud:
         """
         Fill this object from a 2D numpy array (float32)
         """
-        assert arr.shape[1] == 3
+        assert arr.shape[1] == 6
 
         cdef cnp.npy_intp npts = arr.shape[0]
         self.resize(npts)
@@ -183,7 +201,7 @@ cdef class PointCloud:
         for i in range(npts):
             p = cpp.getptr(self.thisptr, i)
             p.x, p.y, p.z = arr[i, 0], arr[i, 1], arr[i, 2]
-            p.rgb = 0   # TODO: assign a sensible value (black by default?)
+            p.rgb = rgb_to_float(arr[i, 3], arr[i, 4], arr[i, 5])
 
     @cython.boundscheck(False)
     def to_array(self):
@@ -195,14 +213,18 @@ cdef class PointCloud:
         cdef cnp.ndarray[cnp.float32_t, ndim=2, mode="c"] result
         cdef cpp.PointXYZRGB *p
 
-        result = np.empty((n, 3), dtype=np.float32)
+        result = np.empty((n, 6), dtype=np.float32)
 
         for i in range(n):
             p = cpp.getptr(self.thisptr, i)
             result[i, 0] = p.x
             result[i, 1] = p.y
             result[i, 2] = p.z
-            p.rgb   # TODO: return RBG value ? Or just ignore it...
+            p_r, p_g,p_b = float_to_rgb(p.rgb)
+            result[i, 3] = p_r
+            result[i, 4] = p_g
+            result[i, 5] = p_b
+
         return result
 
     def from_list(self, _list):
@@ -217,8 +239,8 @@ cdef class PointCloud:
         self.thisptr.height = 1
         for i, l in enumerate(_list):
             p = cpp.getptr(self.thisptr, i)
-            p.x, p.y, p.z = l
-            p.rgb = 0   # TODO: add RGB value 
+            p.x, p.y, p.z = l[0:3]
+            p.rgb = rgb_to_float(l[3], l[4], l[5])
 
     def to_list(self):
         """
@@ -234,8 +256,8 @@ cdef class PointCloud:
         Return a point (3-tuple) at the given row/column
         """
         cdef cpp.PointXYZRGB *p = cpp.getptr_at(self.thisptr, row, col)
-        return p.x, p.y, p.z
-        # TODO: Return RGB value ?
+        p_r,p_g,p_b = float_to_rgb(p.rgb)
+        return p.x, p.y, p.z,p_r,p_g,p_b
 
     def __getitem__(self, cnp.npy_intp idx):
         cdef cpp.PointXYZRGB *p = cpp.getptr_at(self.thisptr, idx)
@@ -596,7 +618,7 @@ cdef cpp.PointXYZRGB to_point_t(point):
     p.x = point[0]
     p.y = point[1]
     p.z = point[2]
-    p.rgb = 0   # TODO: add RGB data
+    p.rgb = rgb_to_float(point[3], point[4], point[5])
     return p
 
 cdef class OctreePointCloud:

--- a/pcl/minipcl.cpp
+++ b/pcl/minipcl.cpp
@@ -8,13 +8,13 @@
 #include "minipcl.h"
 
 // set ksearch and radius to < 0 to disable 
-void mpcl_compute_normals(pcl::PointCloud<pcl::PointXYZ> &cloud,
+void mpcl_compute_normals(pcl::PointCloud<pcl::PointXYZRGB> &cloud,
                           int ksearch,
                           double searchRadius,
                           pcl::PointCloud<pcl::Normal> &out)
 {
-    pcl::search::KdTree<pcl::PointXYZ>::Ptr tree (new pcl::search::KdTree<pcl::PointXYZ> ());
-    pcl::NormalEstimation<pcl::PointXYZ, pcl::Normal> ne;
+    pcl::search::KdTree<pcl::PointXYZRGB>::Ptr tree (new pcl::search::KdTree<pcl::PointXYZRGB> ());
+    pcl::NormalEstimation<pcl::PointXYZRGB, pcl::Normal> ne;
 
     ne.setSearchMethod (tree);
     ne.setInputCloud (cloud.makeShared());
@@ -25,20 +25,20 @@ void mpcl_compute_normals(pcl::PointCloud<pcl::PointXYZ> &cloud,
     ne.compute (out);
 }
 
-void mpcl_sacnormal_set_axis(pcl::SACSegmentationFromNormals<pcl::PointXYZ, pcl::Normal> &sac,
+void mpcl_sacnormal_set_axis(pcl::SACSegmentationFromNormals<pcl::PointXYZRGB, pcl::Normal> &sac,
                              double ax, double ay, double az)
 {
     Eigen::Vector3f vect(ax,ay,az);
     sac.setAxis(vect);
 }
 
-void mpcl_extract(pcl::PointCloud<pcl::PointXYZ> &incloud,
-                  pcl::PointCloud<pcl::PointXYZ> &outcloud,
+void mpcl_extract(pcl::PointCloud<pcl::PointXYZRGB> &incloud,
+                  pcl::PointCloud<pcl::PointXYZRGB> &outcloud,
                   pcl::PointIndices *indices,
                   bool negative)
 {
     pcl::PointIndices::Ptr indicesptr (indices);
-    pcl::ExtractIndices<pcl::PointXYZ> ext;
+    pcl::ExtractIndices<pcl::PointXYZRGB> ext;
     ext.setInputCloud(incloud.makeShared());
     ext.setIndices(indicesptr);
     ext.setNegative (negative);

--- a/pcl/minipcl.h
+++ b/pcl/minipcl.h
@@ -4,16 +4,16 @@
 #include <pcl/point_types.h>
 #include <pcl/segmentation/sac_segmentation.h>
 
-void mpcl_compute_normals(pcl::PointCloud<pcl::PointXYZ> &cloud,
+void mpcl_compute_normals(pcl::PointCloud<pcl::PointXYZRGB> &cloud,
                           int ksearch,
                           double searchRadius,
                           pcl::PointCloud<pcl::Normal> &out);
 
-void mpcl_sacnormal_set_axis(pcl::SACSegmentationFromNormals<pcl::PointXYZ, pcl::Normal> &sac,
+void mpcl_sacnormal_set_axis(pcl::SACSegmentationFromNormals<pcl::PointXYZRGB, pcl::Normal> &sac,
                              double ax, double ay, double az);
 
-void mpcl_extract(pcl::PointCloud<pcl::PointXYZ> &incloud,
-                  pcl::PointCloud<pcl::PointXYZ> &outcloud,
+void mpcl_extract(pcl::PointCloud<pcl::PointXYZRGB> &incloud,
+                  pcl::PointCloud<pcl::PointXYZRGB> &outcloud,
                   pcl::PointIndices *indices,
                   bool negative);
 

--- a/pcl/pcl_defs.pxd
+++ b/pcl/pcl_defs.pxd
@@ -23,9 +23,9 @@ cdef extern from "pcl/point_cloud.h" namespace "pcl":
 
 cdef extern from "indexing.hpp":
     # Use these instead of operator[] or at.
-    PointXYZ *getptr(PointCloud[PointXYZ] *, size_t)
-    PointXYZ *getptr_at(PointCloud[PointXYZ] *, size_t) except +
-    PointXYZ *getptr_at(PointCloud[PointXYZ] *, int, int) except +
+    PointXYZRGB *getptr(PointCloud[PointXYZRGB] *, size_t)
+    PointXYZRGB *getptr_at(PointCloud[PointXYZRGB] *, size_t) except +
+    PointXYZRGB *getptr_at(PointCloud[PointXYZRGB] *, int, int) except +
 
 cdef extern from "pcl/point_types.h" namespace "pcl":
     cdef struct PointXYZ:
@@ -33,6 +33,12 @@ cdef extern from "pcl/point_types.h" namespace "pcl":
         float x
         float y
         float z
+    cdef struct PointXYZRGB:
+        PointXYZRGB()
+        float x
+        float y
+        float z
+        float rgb
     cdef struct Normal:
         pass
 
@@ -63,8 +69,8 @@ cdef extern from "pcl/segmentation/sac_segmentation.h" namespace "pcl":
         void setInputCloud (shared_ptr[PointCloud[T]])
         void segment (PointIndices, ModelCoefficients)
 
-ctypedef SACSegmentation[PointXYZ] SACSegmentation_t
-ctypedef SACSegmentationFromNormals[PointXYZ,Normal] SACSegmentationNormal_t
+ctypedef SACSegmentation[PointXYZRGB] SACSegmentation_t
+ctypedef SACSegmentationFromNormals[PointXYZRGB,Normal] SACSegmentationNormal_t
 
 cdef extern from "pcl/surface/mls.h" namespace "pcl":
     cdef cppclass MovingLeastSquares[I,O]:
@@ -75,7 +81,7 @@ cdef extern from "pcl/surface/mls.h" namespace "pcl":
         void setPolynomialFit(int)
         void process (PointCloud[O])
 
-ctypedef MovingLeastSquares[PointXYZ,PointXYZ] MovingLeastSquares_t
+ctypedef MovingLeastSquares[PointXYZRGB,PointXYZRGB] MovingLeastSquares_t
 
 cdef extern from "pcl/search/kdtree.h" namespace "pcl::search":
     cdef cppclass KdTree[T]:
@@ -85,8 +91,8 @@ cdef extern from "Eigen/src/Core/util/Memory.h" namespace "Eigen":
     cdef cppclass aligned_allocator[T]:
         pass
 
-ctypedef aligned_allocator[PointXYZ] aligned_allocator_t 
-ctypedef vector2[PointXYZ, aligned_allocator_t] AlignedPointTVector_t
+ctypedef aligned_allocator[PointXYZRGB] aligned_allocator_t 
+ctypedef vector2[PointXYZRGB, aligned_allocator_t] AlignedPointTVector_t
 
 cdef extern from "pcl/octree/octree_pointcloud.h" namespace "pcl::octree":
     cdef cppclass OctreePointCloud[T]:
@@ -98,16 +104,16 @@ cdef extern from "pcl/octree/octree_pointcloud.h" namespace "pcl::octree":
         void deleteTree()
         bool isVoxelOccupiedAtPoint(double, double, double)
         int getOccupiedVoxelCenters(AlignedPointTVector_t)	
-        void deleteVoxelAtPoint(PointXYZ)
+        void deleteVoxelAtPoint(PointXYZRGB)
 
-ctypedef OctreePointCloud[PointXYZ] OctreePointCloud_t
+ctypedef OctreePointCloud[PointXYZRGB] OctreePointCloud_t
 
 cdef extern from "pcl/octree/octree_search.h" namespace "pcl::octree":
     cdef cppclass OctreePointCloudSearch[T]:
         OctreePointCloudSearch(double)
-        int radiusSearch (PointXYZ, double, vector[int], vector[float], unsigned int)
+        int radiusSearch (PointXYZRGB, double, vector[int], vector[float], unsigned int)
 
-ctypedef OctreePointCloudSearch[PointXYZ] OctreePointCloudSearch_t
+ctypedef OctreePointCloudSearch[PointXYZRGB] OctreePointCloudSearch_t
 
 cdef extern from "pcl/ModelCoefficients.h" namespace "pcl":
     cdef struct ModelCoefficients:
@@ -128,22 +134,22 @@ ctypedef PointIndices PointIndices_t
 ctypedef shared_ptr[PointIndices] PointIndicesPtr_t
 
 cdef extern from "pcl/io/pcd_io.h" namespace "pcl::io":
-    int load(string file_name, PointCloud[PointXYZ] &cloud) nogil except +
+    int load(string file_name, PointCloud[PointXYZRGB] &cloud) nogil except +
     int loadPCDFile(string file_name,
-                    PointCloud[PointXYZ] &cloud) nogil except +
-    int savePCDFile(string file_name, PointCloud[PointXYZ] &cloud,
+                    PointCloud[PointXYZRGB] &cloud) nogil except +
+    int savePCDFile(string file_name, PointCloud[PointXYZRGB] &cloud,
                     bool binary_mode) nogil except +
 
 cdef extern from "pcl/io/ply_io.h" namespace "pcl::io":
     int loadPLYFile(string file_name,
-                    PointCloud[PointXYZ] &cloud) nogil except +
-    int savePLYFile(string file_name, PointCloud[PointXYZ] &cloud,
+                    PointCloud[PointXYZRGB] &cloud) nogil except +
+    int savePLYFile(string file_name, PointCloud[PointXYZRGB] &cloud,
                     bool binary_mode) nogil except +
 
 #http://dev.pointclouds.org/issues/624
 #cdef extern from "pcl/io/ply_io.h" namespace "pcl::io":
-#    int loadPLYFile (string file_name, PointCloud[PointXYZ] cloud)
-#    int savePLYFile (string file_name, PointCloud[PointXYZ] cloud, bool binary_mode)
+#    int loadPLYFile (string file_name, PointCloud[PointXYZRGB] cloud)
+#    int savePLYFile (string file_name, PointCloud[PointXYZRGB] cloud, bool binary_mode)
 
 cdef extern from "pcl/sample_consensus/model_types.h" namespace "pcl":
     cdef enum SacModel:
@@ -175,9 +181,9 @@ cdef extern from "pcl/sample_consensus/method_types.h" namespace "pcl":
         SAC_MLESAC = 5
         SAC_PROSAC = 6
 
-ctypedef PointCloud[PointXYZ] PointCloud_t
+ctypedef PointCloud[PointXYZRGB] PointCloud_t
 ctypedef PointCloud[Normal] PointNormalCloud_t
-ctypedef shared_ptr[PointCloud[PointXYZ]] PointCloudPtr_t
+ctypedef shared_ptr[PointCloud[PointXYZRGB]] PointCloudPtr_t
 
 cdef extern from "pcl/filters/statistical_outlier_removal.h" namespace "pcl":
     cdef cppclass StatisticalOutlierRemoval[T]:
@@ -188,7 +194,7 @@ cdef extern from "pcl/filters/statistical_outlier_removal.h" namespace "pcl":
         void setInputCloud (shared_ptr[PointCloud[T]])
         void filter(PointCloud[T] c)
 
-ctypedef StatisticalOutlierRemoval[PointXYZ] StatisticalOutlierRemoval_t
+ctypedef StatisticalOutlierRemoval[PointXYZRGB] StatisticalOutlierRemoval_t
 
 cdef extern from "pcl/filters/voxel_grid.h" namespace "pcl":
     cdef cppclass VoxelGrid[T]:
@@ -197,7 +203,7 @@ cdef extern from "pcl/filters/voxel_grid.h" namespace "pcl":
         void setInputCloud (shared_ptr[PointCloud[T]])
         void filter(PointCloud[T] c)
 
-ctypedef VoxelGrid[PointXYZ] VoxelGrid_t
+ctypedef VoxelGrid[PointXYZRGB] VoxelGrid_t
 
 cdef extern from "pcl/filters/passthrough.h" namespace "pcl":
     cdef cppclass PassThrough[T]:
@@ -207,7 +213,7 @@ cdef extern from "pcl/filters/passthrough.h" namespace "pcl":
         void setInputCloud (shared_ptr[PointCloud[T]])
         void filter(PointCloud[T] c)
 
-ctypedef PassThrough[PointXYZ] PassThrough_t
+ctypedef PassThrough[PointXYZRGB] PassThrough_t
 
 cdef extern from "pcl/kdtree/kdtree_flann.h" namespace "pcl":
     cdef cppclass KdTreeFLANN[T]:
@@ -216,4 +222,4 @@ cdef extern from "pcl/kdtree/kdtree_flann.h" namespace "pcl":
         int nearestKSearch (PointCloud[T],
           int, int, vector[int], vector[float])
 
-ctypedef KdTreeFLANN[PointXYZ] KdTreeFLANN_t
+ctypedef KdTreeFLANN[PointXYZRGB] KdTreeFLANN_t


### PR DESCRIPTION
Basically, just changed PointXYZ to PointXYZRGB. Now it is now possible to load a point cloud (for example from PLY) and preserve colour information.

At least as far as I can see, all methods working with PointXYZ should work with PointXYZRGB, so I we could just replace the point type completely (unless there is a good reason to stick to PointXYZ an have PointXYZRGB clouds being a separate class).
